### PR TITLE
Enlist the v0.1.0 version of the Pulumi preconfigured job plugin in plugins.json

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -5,6 +5,14 @@
       "provider": "https://github.com/pulumi",
       "releases": [
         {
+          "version": "v0.1.0",
+          "date": "2021-01-29T00:42:50.629739Z",
+          "requires": "orca>=0.0.0,deck>=0.0.0",
+          "sha512sum": "9fbd3f20985cbd03f52468af92588037662a62dab8c54437f16c86be5a4e7717aa585094db0e47ef0941008f287220109159c0ec20a38f8ff1e6a7a7a08d7ae8",
+          "state": "RELEASE",
+          "url": "https://github.com/pulumi/spinnaker-preconfigured-job-plugin/releases/download/v0.1.0/spinnaker-preconfigured-job-plugin-v0.1.0.zip"
+        },
+        {
           "version": "0.0.1",
           "date": "2020-06-15T21:51:59.629Z",
           "requires": "orca>=0.0.0",


### PR DESCRIPTION
The automated workflow to create a PR [failed](https://github.com/pulumi/spinnaker-preconfigured-job-plugin/runs/1787455460?check_suite_focus=true#step:10:14) due to an issue in the GitHub Action that we use. I opened an [issue](https://github.com/armory-io/plugin-metadata-updater/issues/1) in the `armory-io/plugin-metadata-updater` repo. But in the meantime, I'd like to add the version manually to the JSON file.